### PR TITLE
Added spec file examples to all environment and service examples.

### DIFF
--- a/environment-templates/ecs-ec2-env/spec/spec.yaml
+++ b/environment-templates/ecs-ec2-env/spec/spec.yaml
@@ -1,0 +1,12 @@
+proton: EnvironmentSpec
+spec:
+  vpc_cidr: 10.0.0.0/16
+  public_subnet_one_cidr: 10.0.0.0/18
+  public_subnet_two_cidr: 10.0.64.0/18
+  private_subnet_one_cidr: 10.0.128.0/18
+  private_subnet_two_cidr: 10.0.192.0/18
+  subnet_type: public
+  DesiredCapacity: 1
+  MaxSize: 6
+  ECSAMI: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+  InstanceType: c4.xlarge

--- a/environment-templates/fargate-env/spec/spec.yaml
+++ b/environment-templates/fargate-env/spec/spec.yaml
@@ -1,0 +1,7 @@
+proton: EnvironmentSpec
+spec:
+  vpc_cidr: 10.0.0.0/16
+  public_subnet_one_cidr: 10.0.0.0/18
+  public_subnet_two_cidr: 10.0.64.0/18
+  private_subnet_one_cidr: 10.0.128.0/18
+  private_subnet_two_cidr: 10.0.192.0/18

--- a/environment-templates/vpc-env/spec/spec.yaml
+++ b/environment-templates/vpc-env/spec/spec.yaml
@@ -1,0 +1,7 @@
+proton: EnvironmentSpec
+spec:
+  vpc_cidr: 10.0.0.0/16
+  public_subnet_one_cidr: 10.0.0.0/18
+  public_subnet_two_cidr: 10.0.64.0/18
+  private_subnet_one_cidr: 10.0.128.0/18
+  private_subnet_two_cidr: 10.0.192.0/18

--- a/service-templates/apigw-lambda-svc/spec/spec.yaml
+++ b/service-templates/apigw-lambda-svc/spec/spec.yaml
@@ -1,0 +1,8 @@
+proton: ServiceSpec
+pipeline:
+  code_dir: lambda-ping-sns
+  unit_test_command: echo 'add your unit test command here'
+  packaging_command: zip function.zip app.js
+instances:
+  - name: apigw-lambda-svc-prod
+    environment: vpc-env-prod

--- a/service-templates/apprunner-svc/spec/spec.yaml
+++ b/service-templates/apprunner-svc/spec/spec.yaml
@@ -1,0 +1,8 @@
+proton: ServiceSpec
+pipeline:
+  service_dir: ecs-static-website
+  dockerfile: Dockerfile
+  unit_test_command: echo 'add your unit test command here'
+instances:
+  - name: apprunner-svc-prod
+    environment: vpc-env-prod

--- a/service-templates/backend-ecs-ec2-svc/spec/spec.yaml
+++ b/service-templates/backend-ecs-ec2-svc/spec/spec.yaml
@@ -1,0 +1,8 @@
+proton: ServiceSpec
+pipeline:
+  service_dir: ecs-backend
+  dockerfile: Dockerfile
+  unit_test_command: echo 'add your unit test command here'
+instances:
+  - name: backend-ecs-ec2-svc-prod
+    environment: ecs-ec2-env-prod

--- a/service-templates/backend-fargate-svc/spec/spec.yaml
+++ b/service-templates/backend-fargate-svc/spec/spec.yaml
@@ -1,0 +1,8 @@
+proton: ServiceSpec
+pipeline:
+  service_dir: ecs-backend
+  dockerfile: Dockerfile
+  unit_test_command: echo 'add your unit test command here'
+instances:
+  - name: backend-fargate-svc-prod
+    environment: fargate-env-prod

--- a/service-templates/load-balanced-ecs-ec2-svc/spec/spec.yaml
+++ b/service-templates/load-balanced-ecs-ec2-svc/spec/spec.yaml
@@ -1,0 +1,8 @@
+proton: ServiceSpec
+pipeline:
+  service_dir: ecs-static-website
+  dockerfile: Dockerfile
+  unit_test_command: echo 'add your unit test command here'
+instances:
+  - name: load-balanced-ecs-ec2-svc-prod
+    environment: ecs-ec2-env-prod

--- a/service-templates/load-balanced-fargate-svc/spec/spec.yaml
+++ b/service-templates/load-balanced-fargate-svc/spec/spec.yaml
@@ -1,0 +1,8 @@
+proton: ServiceSpec
+pipeline:
+  service_dir: ecs-static-website
+  dockerfile: Dockerfile
+  unit_test_command: echo 'add your unit test command here'
+instances:
+  - name: load-balanced-fargate-svc-prod
+    environment: fargate-env-prod

--- a/service-templates/scheduled-ecs-ec2-svc/spec/spec.yaml
+++ b/service-templates/scheduled-ecs-ec2-svc/spec/spec.yaml
@@ -1,0 +1,8 @@
+proton: ServiceSpec
+pipeline:
+  service_dir: ecs-ping-sns
+  dockerfile: Dockerfile
+  unit_test_command: echo 'add your unit test command here'
+instances:
+  - name: scheduled-ecs-ec2-svc-prod
+    environment: ecs-ec2-env-prod

--- a/service-templates/scheduled-fargate-svc/spec/spec.yaml
+++ b/service-templates/scheduled-fargate-svc/spec/spec.yaml
@@ -1,0 +1,8 @@
+proton: ServiceSpec
+pipeline:
+  service_dir: ecs-ping-sns
+  dockerfile: Dockerfile
+  unit_test_command: echo 'add your unit test command here'
+instances:
+  - name: scheduled-fargate-svc-prod
+    environment: fargate-env-prod

--- a/service-templates/scheduled-lambda-svc/spec/spec.yaml
+++ b/service-templates/scheduled-lambda-svc/spec/spec.yaml
@@ -1,0 +1,8 @@
+proton: ServiceSpec
+pipeline:
+  code_dir: lambda-ping-sns
+  unit_test_command: echo 'add your unit test command here'
+  packaging_command: zip function.zip app.js
+instances:
+  - name: scheduled-lambda-svc-prod
+    environment: vpc-env-prod

--- a/service-templates/worker-ecs-ec2-svc/spec/spec.yaml
+++ b/service-templates/worker-ecs-ec2-svc/spec/spec.yaml
@@ -1,0 +1,8 @@
+proton: ServiceSpec
+pipeline:
+  service_dir: ecs-worker
+  dockerfile: Dockerfile
+  unit_test_command: echo 'add your unit test command here'
+instances:
+  - name: worker-ecs-ec2-svc-prod
+    environment: ecs-ec2-env-prod

--- a/service-templates/worker-fargate-svc/spec/spec.yaml
+++ b/service-templates/worker-fargate-svc/spec/spec.yaml
@@ -1,0 +1,8 @@
+proton: ServiceSpec
+pipeline:
+  service_dir: ecs-worker
+  dockerfile: Dockerfile
+  unit_test_command: echo 'add your unit test command here'
+instances:
+  - name: worker-fargate-svc-prod
+    environment: fargate-env-prod

--- a/service-templates/worker-lambda-svc/spec/spec.yaml
+++ b/service-templates/worker-lambda-svc/spec/spec.yaml
@@ -1,0 +1,8 @@
+proton: ServiceSpec
+pipeline:
+  code_dir: lambda-worker
+  unit_test_command: echo 'add your unit test command here'
+  packaging_command: zip function.zip app.js
+instances:
+  - name: worker-lambda-svc-prod
+    environment: vpc-env-prod


### PR DESCRIPTION
*Issue #, if available:* Spec examples are missing from our new environment and service template examples (they existed in the old ones).

*Description of changes:*
Added `spec/spec.yaml` under each example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
