### PR TITLE
adds health check path

### DIFF
--- a/service-templates/load-balanced-fargate-svc/v1/instance_infrastructure/main.tf
+++ b/service-templates/load-balanced-fargate-svc/v1/instance_infrastructure/main.tf
@@ -44,15 +44,19 @@ resource "aws_lb_listener" "service_lb_public_listener" {
 }
 
 resource "aws_lb_target_group" "service_lb_public_listener_target_group" {
-  port     = var.service_instance.inputs.port
-  protocol = var.service_instance.inputs.loadbalancer_type == "application" ? "HTTP" : "TCP"
+  port        = var.service_instance.inputs.port
+  protocol    = var.service_instance.inputs.loadbalancer_type == "application" ? "HTTP" : "TCP"
+  target_type = "ip"
+  vpc_id      = var.environment.outputs.VpcId
 
   stickiness {
     enabled = false
     type    = var.service_instance.inputs.loadbalancer_type == "application" ? "lb_cookie" : "source_ip"
   }
-  target_type = "ip"
-  vpc_id      = var.environment.outputs.VpcId
+
+  health_check {
+    path = var.service_instance.health_check_path
+  }
 }
 
 resource "aws_iam_role" "ecs_task_execution_role" {

--- a/service-templates/load-balanced-fargate-svc/v1/schema/schema.yaml
+++ b/service-templates/load-balanced-fargate-svc/v1/schema/schema.yaml
@@ -15,6 +15,11 @@ schema:
           default: 80
           minimum: 0
           maximum: 65535
+        health_check_path:
+          title: Health Check Path
+          description: Destination for the health check request
+          type: string
+          default: /
         desired_count:
           type: number
           description: "The default number of Fargate tasks you want running"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In order to be able to use a greater range of apps when demoing the sample `load-balanced-fargate-svc` template, it would be nice to be able to change the health check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
