### PR TITLE
Updating readme to redirect to codebuild provisioning example repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,25 @@
 ## AWS Proton Sample Terraform Templates
 
-This repository is a curated list of sample templates to use within AWS Proton that are authored for integration with [Terraform](https://www.terraform.io/).
+## Choose your provisioning model
+
+If you are looking for pull request based (aka self-managed) provisioning, the examples in this repository are sufficient.
+
+If you are looking for CodeBuild provisioning examples, they can be found [here](https://github.com/aws-containers/proton-codebuild-provisioning-examples/tree/main/terraform).
+
+For more information on the various provisioning models with AWS Proton, check out the [documentation](https://docs.aws.amazon.com/proton/latest/userguide/ag-works-prov-methods.html).
+
+## Description
+
+This repository is a curated list of sample templates to use within AWS Proton that are authored for integration with [Terraform](https://www.terraform.io/) using [self-managed provisioning](https://docs.aws.amazon.com/proton/latest/userguide/ag-works-prov-methods.html).
 
 To use this repository, browse to the folder that corresponds to the template that you want to use. You will find there all the information you need to create environment and service templates and to deploy the corresponding environments and services. You will also find a link to a repository with basic code that runs on each one of them, in case you want to fork it to use it as the basis for your deployment.
 
 ### Registering Templates Using Template Sync
+
 All of the Templates in this directory are set up to work with [AWS Proton Template Sync](https://docs.aws.amazon.com/proton/latest/adminguide/create-template-sync.html). This repository is also a Github Template Repository. So you can click "Use this template" on the home page of this repo and that will create an identical repo in your account, which you can then use with template sync.
 
 ### Running Terraform Using AWS Proton Self-managed Provisioning
+
 If you need an example of how to run your Terraform code, head on over to [this repo](https://github.com/aws-samples/aws-proton-terraform-github-actions-sample) where we offer an example of running Terraform using GitHub Actions.
 
 ### Local Development
@@ -38,4 +50,3 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 ## License
 
 This library is licensed under the MIT-0 License. See the LICENSE file.
-


### PR DESCRIPTION
*Description of changes:*

Update to README to ensure that folks looking for codebuild examples can easily get to those sample templates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
