### PR TITLE
Upgrade deprecated runtime nodejs12.x

### DIFF
--- a/lambda-vpc/sample-lambda-function-template/v1/schema/schema.yaml
+++ b/lambda-vpc/sample-lambda-function-template/v1/schema/schema.yaml
@@ -21,7 +21,7 @@ schema:
         lambda_runtime:
           type: string
           description: "The runtime for your Lambda service"
-          enum: ["nodejs12.x", "python3.8", "ruby2.7", "java11", "go1.x", "dotnetcore3.1"]
+          enum: ["nodejs16.x", "python3.8", "ruby2.7", "java11", "go1.x", "dotnetcore3.1"]
         function_s3_bucket:
           type: string
           description: "The s3 bucket where the function code is stored"

--- a/service-templates/apigw-lambda-svc/dev-resources/proton.auto.tfvars.json
+++ b/service-templates/apigw-lambda-svc/dev-resources/proton.auto.tfvars.json
@@ -13,7 +13,7 @@
       "inputs": {
       },
       "outputs": {
-        "LambdaRuntime": "nodejs12.x"
+        "LambdaRuntime": "nodejs16.x"
       },
       "environment": {
         "account_id": "",
@@ -39,7 +39,7 @@
   "service_instance": {
     "name": "instance1",
     "inputs": {
-      "lambda_runtime": "nodejs12.x",
+      "lambda_runtime": "nodejs16.x",
       "lambda_handler": "app.handler",
       "lambda_bucket": "REPLACE_ME",
       "lambda_key": "REPLACE_ME"

--- a/service-templates/apigw-lambda-svc/v1/pipeline_infrastructure/main.tf
+++ b/service-templates/apigw-lambda-svc/v1/pipeline_infrastructure/main.tf
@@ -52,7 +52,7 @@ resource "aws_codebuild_project" "build_project" {
                       "runtime-versions":
                       ${tomap({
     "ruby2.7"       = jsonencode({ "ruby" = "2.7" })
-    "nodejs12.x"    = jsonencode({ "nodejs" = "12.x" })
+    "nodejs16.x"    = jsonencode({ "nodejs" = "12.x" })
     "python3.8"     = jsonencode({ "python" = "3.8" })
     "java11"        = jsonencode({ "java" = "openjdk11.x" })
     "dotnetcore3.1" = jsonencode({ "dotnet" : "3.1" })

--- a/service-templates/apigw-lambda-svc/v1/schema/schema.yaml
+++ b/service-templates/apigw-lambda-svc/v1/schema/schema.yaml
@@ -30,8 +30,8 @@ schema:
         lambda_runtime:
           type: string
           description: "The runtime for your Lambda service"
-          enum: ["nodejs12.x", "python3.8", "ruby2.7", "java11", "go1.x", "dotnetcore3.1"]
-          default: "nodejs12.x"
+          enum: ["nodejs16.x", "python3.8", "ruby2.7", "java11", "go1.x", "dotnetcore3.1"]
+          default: "nodejs16.x"
         lambda_bucket:
           type: string
           description: "The s3 bucket for your application code"

--- a/service-templates/backend-fargate-svc/dev-resources/proton.auto.tfvars.json
+++ b/service-templates/backend-fargate-svc/dev-resources/proton.auto.tfvars.json
@@ -13,7 +13,7 @@
       "inputs": {
       },
       "outputs": {
-        "LambdaRuntime": "nodejs12.x"
+        "LambdaRuntime": "nodejs16.x"
       },
       "environment": {
         "account_id": "",

--- a/service-templates/load-balanced-ecs-ec2-svc/dev-resources/proton.auto.tfvars.json
+++ b/service-templates/load-balanced-ecs-ec2-svc/dev-resources/proton.auto.tfvars.json
@@ -20,7 +20,7 @@
         "desired_count": 1
       },
       "outputs": {
-        "LambdaRuntime": "nodejs12.x"
+        "LambdaRuntime": "nodejs16.x"
       },
       "environment": {
         "account_id": "",

--- a/service-templates/scheduled-lambda-svc/dev-resources/instance/proton.auto.tfvars.json
+++ b/service-templates/scheduled-lambda-svc/dev-resources/instance/proton.auto.tfvars.json
@@ -27,7 +27,7 @@
       "lambda_handler": "app.handler",
       "lambda_memory": 512,
       "lambda_timeout": 30,
-      "lambda_runtime": "nodejs12.x",
+      "lambda_runtime": "nodejs16.x",
       "subnet_type": "public",
       "schedule_expression": "REPLACE_ME"
     },

--- a/service-templates/scheduled-lambda-svc/dev-resources/pipeline/proton.auto.tfvars.json
+++ b/service-templates/scheduled-lambda-svc/dev-resources/pipeline/proton.auto.tfvars.json
@@ -20,13 +20,13 @@
         "lambda_handler": "app.handler",
         "lambda_memory": 512,
         "lambda_timeout": 30,
-        "lambda_runtime": "nodejs12.x",
+        "lambda_runtime": "nodejs16.x",
         "subnet_type": "public",
         "schedule_expression": "REPLACE_ME"
       },
       "outputs": {
         "LambdaFunction": "REPLACE_ME",
-        "LambdaRuntime": "nodejs12.x"
+        "LambdaRuntime": "nodejs16.x"
       },
       "environment": {
         "account_id": "REPLACE_ME",

--- a/service-templates/scheduled-lambda-svc/v1/pipeline_infrastructure/main.tf
+++ b/service-templates/scheduled-lambda-svc/v1/pipeline_infrastructure/main.tf
@@ -52,7 +52,7 @@ resource "aws_codebuild_project" "build_project" {
                       "runtime-versions":
                       ${tomap({
     "ruby2.7"       = jsonencode({ "ruby" = "2.7" })
-    "nodejs12.x"    = jsonencode({ "nodejs" = "12.x" })
+    "nodejs16.x"    = jsonencode({ "nodejs" = "12.x" })
     "python3.8"     = jsonencode({ "python" = "3.8" })
     "java11"        = jsonencode({ "java" = "openjdk11.x" })
     "dotnetcore3.1" = jsonencode({ "dotnet" : "3.1" })

--- a/service-templates/scheduled-lambda-svc/v1/schema/schema.yaml
+++ b/service-templates/scheduled-lambda-svc/v1/schema/schema.yaml
@@ -30,8 +30,8 @@ schema:
         lambda_runtime:
           type: string
           description: "The runtime for your Lambda service"
-          enum: ["nodejs12.x", "python3.8", "ruby2.7", "java11", "go1.x", "dotnetcore3.1"]
-          default: "nodejs12.x"
+          enum: ["nodejs16.x", "python3.8", "ruby2.7", "java11", "go1.x", "dotnetcore3.1"]
+          default: "nodejs16.x"
         code_bucket:
           type: string
           description: "The s3 bucket to your application"

--- a/service-templates/worker-ecs-ec2-svc/dev-resources/proton.auto.tfvars.json
+++ b/service-templates/worker-ecs-ec2-svc/dev-resources/proton.auto.tfvars.json
@@ -13,7 +13,7 @@
       "inputs": {
       },
       "outputs": {
-        "LambdaRuntime": "nodejs12.x"
+        "LambdaRuntime": "nodejs16.x"
       },
       "environment": {
         "account_id": "",

--- a/service-templates/worker-fargate-svc/dev-resources/proton.auto.tfvars.json
+++ b/service-templates/worker-fargate-svc/dev-resources/proton.auto.tfvars.json
@@ -13,7 +13,7 @@
       "inputs": {
       },
       "outputs": {
-        "LambdaRuntime": "nodejs12.x"
+        "LambdaRuntime": "nodejs16.x"
       },
       "environment": {
         "account_id": "",

--- a/service-templates/worker-lambda-svc/dev-resources/proton.auto.tfvars.json
+++ b/service-templates/worker-lambda-svc/dev-resources/proton.auto.tfvars.json
@@ -13,7 +13,7 @@
       "inputs": {
       },
       "outputs": {
-        "LambdaRuntime": "nodejs12.x"
+        "LambdaRuntime": "nodejs16.x"
       },
       "environment": {
         "account_id": "",
@@ -45,7 +45,7 @@
     "name": "instance1",
     "inputs": {
       "subnet_type": "private",
-      "lambda_runtime": "nodejs12.x",
+      "lambda_runtime": "nodejs16.x",
       "lambda_handler": "app.handler",
       "lambda_key": "4/function.zip"
     }

--- a/service-templates/worker-lambda-svc/v1/pipeline_infrastructure/main.tf
+++ b/service-templates/worker-lambda-svc/v1/pipeline_infrastructure/main.tf
@@ -52,7 +52,7 @@ resource "aws_codebuild_project" "build_project" {
                       "runtime-versions":
                       ${tomap({
     "ruby2.7"       = jsonencode({ "ruby" = "2.7" })
-    "nodejs12.x"    = jsonencode({ "nodejs" = "12.x" })
+    "nodejs16.x"    = jsonencode({ "nodejs" = "12.x" })
     "python3.8"     = jsonencode({ "python" = "3.8" })
     "java11"        = jsonencode({ "java" = "openjdk11.x" })
     "dotnetcore3.1" = jsonencode({ "dotnet" : "3.1" })

--- a/service-templates/worker-lambda-svc/v1/schema/schema.yaml
+++ b/service-templates/worker-lambda-svc/v1/schema/schema.yaml
@@ -30,8 +30,8 @@ schema:
         lambda_runtime:
           type: string
           description: "The runtime for your Lambda service"
-          enum: ["nodejs12.x", "python3.8", "ruby2.7", "java11", "go1.x", "dotnetcore3.1"]
-          default: "nodejs12.x"
+          enum: ["nodejs16.x", "python3.8", "ruby2.7", "java11", "go1.x", "dotnetcore3.1"]
+          default: "nodejs16.x"
         lambda_bucket:
           type: string
           description: "The s3 bucket for your application code"


### PR DESCRIPTION
CloudFormation templates in aws-proton-terraform-sample-templates have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs12.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.